### PR TITLE
Feat/요금제비교 결과 UI구현

### DIFF
--- a/client/src/components/ComparePage/BenefitComparisonRow.tsx
+++ b/client/src/components/ComparePage/BenefitComparisonRow.tsx
@@ -1,0 +1,35 @@
+interface BenefitComparisonRowProps {
+  leftContent: string | null;
+  rightContent: string | null;
+  title: string;
+  leftIcon?: string;
+  rightIcon?: string;
+  iconAlt?: string;
+}
+
+const BenefitComparisonRow: React.FC<BenefitComparisonRowProps> = ({
+  leftContent,
+  rightContent,
+  title,
+  leftIcon,
+  rightIcon,
+  iconAlt = 'benefit icon',
+}) => {
+  return (
+    <div className="flex w-full">
+      <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center">
+        {leftIcon && leftContent && <img src={leftIcon} alt={iconAlt} />}
+        <div className="text-xs text-gray500">{leftContent || '-'}</div>
+      </div>
+      <div className="flex-[1] text-sm flex items-center justify-center">
+        {title}
+      </div>
+      <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center">
+        {rightIcon && rightContent && <img src={rightIcon} alt={iconAlt} />}
+        <div className="text-xs text-gray500">{rightContent || '-'}</div>
+      </div>
+    </div>
+  );
+};
+
+export default BenefitComparisonRow;

--- a/client/src/components/ComparePage/ComparisonActionButtons.tsx
+++ b/client/src/components/ComparePage/ComparisonActionButtons.tsx
@@ -1,0 +1,42 @@
+interface ComparisonActionButtonsProps {
+  leftButtonText: string;
+  rightButtonText: string;
+  onLeftClick: () => void;
+  onRightClick: () => void;
+}
+
+const ComparisonActionButtons: React.FC<ComparisonActionButtonsProps> = ({
+  leftButtonText,
+  rightButtonText,
+  onLeftClick,
+  onRightClick,
+}) => {
+  return (
+    <div
+      className="flex flex-col justify-center items-center text-center gap-6 fixed bottom-[29px] max-w-[560px] overflow-visible h-[106px]"
+      style={{ width: 'calc(100% - 40px)' }}
+    >
+      <div className="flex w-full overflow-visible">
+        <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center rounded-[10px] shadow-basic">
+          <button
+            onClick={onLeftClick}
+            className="text-xs text-background-40 font-semibold bg-primary-pink w-full h-[38px] flex items-center justify-center rounded-[10px] cursor-pointer shadow-basic"
+          >
+            {leftButtonText}
+          </button>
+        </div>
+        <div className="flex-[1] text-sm flex items-center justify-center" />
+        <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center rounded-[10px] shadow-basic">
+          <button
+            onClick={onRightClick}
+            className="text-xs text-background-40 font-semibold bg-primary-pink w-full h-[38px] flex items-center justify-center rounded-[10px] cursor-pointer shadow-basic"
+          >
+            {rightButtonText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ComparisonActionButtons;

--- a/client/src/components/ComparePage/ComparisonResult.tsx
+++ b/client/src/components/ComparePage/ComparisonResult.tsx
@@ -1,0 +1,124 @@
+import DataComparisonBar from './DataComparisonBar';
+import BenefitComparisonRow from './BenefitComparisonRow';
+import ComparisonActionButtons from './ComparisonActionButtons';
+import togetherIcon from '@/assets/image/card_family.png';
+import premiumAddonsIcon from '@/assets/icon/special.png';
+import type { Plan } from '@/components/types/Plan';
+
+interface ComparisonResultProps {
+  selectedLeft: Plan;
+  selectedRight: Plan;
+}
+
+const ComparisonResult: React.FC<ComparisonResultProps> = ({
+  selectedLeft,
+  selectedRight,
+}) => {
+  const handleDetailClick = (detailUrl?: string) => {
+    if (detailUrl) {
+      window.open(detailUrl, '_blank');
+    }
+  };
+
+  const leftDataValue =
+    selectedLeft?.dataGb === -1 ? 300 : selectedLeft?.dataGb || 0;
+  const rightDataValue =
+    selectedRight?.dataGb === -1 ? 300 : selectedRight?.dataGb || 0;
+  const leftSharedDataValue =
+    selectedLeft?.sharedDataGb === -1 ? 300 : selectedLeft?.sharedDataGb || 0;
+  const rightSharedDataValue =
+    selectedRight?.sharedDataGb === -1 ? 300 : selectedRight?.sharedDataGb || 0;
+
+  const leftDataLabel =
+    selectedLeft.dataGb === -1 ? '무제한' : `${selectedLeft.dataGb}GB`;
+  const rightDataLabel =
+    selectedRight.dataGb === -1 ? '무제한' : `${selectedRight.dataGb}GB`;
+  const leftSharedDataLabel =
+    selectedLeft.sharedDataGb === -1
+      ? '무제한'
+      : `${selectedLeft.sharedDataGb}GB`;
+  const rightSharedDataLabel =
+    selectedRight.sharedDataGb === -1
+      ? '무제한'
+      : `${selectedRight.sharedDataGb}GB`;
+
+  return (
+    <>
+      <div className="w-full flex flex-col items-center">
+        <div className="flex flex-col justify-center items-center text-center w-full gap-2">
+          <DataComparisonBar
+            leftValue={leftDataValue}
+            rightValue={rightDataValue}
+            leftLabel={leftDataLabel}
+            rightLabel={rightDataLabel}
+            title="데이터"
+          />
+          <DataComparisonBar
+            leftValue={leftSharedDataValue}
+            rightValue={rightSharedDataValue}
+            leftLabel={leftSharedDataLabel}
+            rightLabel={rightSharedDataLabel}
+            title="공유 데이터"
+          />
+        </div>
+
+        <div className="w-full bg-gray200 h-[1px] my-5" />
+
+        <div className="flex flex-col justify-center items-center text-center w-full gap-6 mb-[106px]">
+          <BenefitComparisonRow
+            leftContent={selectedLeft.bundleBenefit || null}
+            rightContent={selectedRight.bundleBenefit || null}
+            title="결합 할인"
+            leftIcon={selectedLeft.bundleBenefit ? togetherIcon : undefined}
+            rightIcon={selectedRight.bundleBenefit ? togetherIcon : undefined}
+            iconAlt="togetherIcon"
+          />
+
+          <BenefitComparisonRow
+            leftContent={
+              selectedLeft.premiumAddons
+                ? `(택1) ${selectedLeft.premiumAddons}`
+                : null
+            }
+            rightContent={
+              selectedRight.premiumAddons
+                ? `(택1) ${selectedRight.premiumAddons}`
+                : null
+            }
+            title="프리미엄 서비스"
+            leftIcon={
+              selectedLeft.premiumAddons ? premiumAddonsIcon : undefined
+            }
+            rightIcon={
+              selectedRight.premiumAddons ? premiumAddonsIcon : undefined
+            }
+            iconAlt="premiumIcon"
+          />
+
+          <BenefitComparisonRow
+            leftContent={
+              selectedLeft.mediaAddons
+                ? `(택1) ${selectedLeft.mediaAddons}`
+                : null
+            }
+            rightContent={
+              selectedRight.mediaAddons
+                ? `(택1) ${selectedRight.mediaAddons}`
+                : null
+            }
+            title="미디어 서비스"
+          />
+        </div>
+      </div>
+
+      <ComparisonActionButtons
+        leftButtonText="자세히 보기"
+        rightButtonText="자세히 보기"
+        onLeftClick={() => handleDetailClick(selectedLeft.detailUrl)}
+        onRightClick={() => handleDetailClick(selectedRight.detailUrl)}
+      />
+    </>
+  );
+};
+
+export default ComparisonResult;

--- a/client/src/components/ComparePage/DataComparisonBar.tsx
+++ b/client/src/components/ComparePage/DataComparisonBar.tsx
@@ -1,0 +1,41 @@
+interface DataComparisonBarProps {
+  leftValue: number;
+  rightValue: number;
+  leftLabel: string;
+  rightLabel: string;
+  title: string;
+}
+
+const DataComparisonBar: React.FC<DataComparisonBarProps> = ({
+  leftValue,
+  rightValue,
+  leftLabel,
+  rightLabel,
+  title,
+}) => {
+  const maxValue = Math.max(leftValue, rightValue);
+  const leftRatio = (leftValue / maxValue) * 100;
+  const rightRatio = (rightValue / maxValue) * 100;
+
+  return (
+    <div className="flex w-full">
+      <div className="flex-[2] relative flex flex-col items-end gap-1">
+        <div
+          className="bg-gradation rounded-l-full h-5"
+          style={{ width: `${leftRatio}%` }}
+        />
+        <div className="text-xs text-gray500">{leftLabel}</div>
+      </div>
+      <div className="flex-[1] text-sm">{title}</div>
+      <div className="flex-[2] relative flex flex-col items-start gap-1">
+        <div
+          className="bg-gradation rounded-r-full h-5"
+          style={{ width: `${rightRatio}%` }}
+        />
+        <div className="text-xs text-gray500">{rightLabel}</div>
+      </div>
+    </div>
+  );
+};
+
+export default DataComparisonBar;

--- a/client/src/components/ComparePage/PlanDetailInfo.tsx
+++ b/client/src/components/ComparePage/PlanDetailInfo.tsx
@@ -1,42 +1,27 @@
-interface Plan {
-  id: string;
-  category: string;
-  name: string;
-  monthlyFee: number;
-  bundleBenefit?: {
-    _id: string;
-    name: string;
-  };
-  basicBenefits?: Array<{
-    _id: string;
-    name: string;
-    description: string;
-  }>;
-  specialBenefits?: {
-    premiumServices: Array<{ _id: string; name: string }>;
-    mediaServices: Array<{ _id: string; name: string }>;
-  };
-  benefits?: string;
-}
+import type { Plan } from '@/components/types/Plan';
 
 interface PlanDetailInfoProps {
   plan: Plan;
 }
 
 const PlanDetailInfo: React.FC<PlanDetailInfoProps> = ({ plan }) => {
-  const formatBenefits = (plan: Plan): string => {
-    if (plan.benefits) return plan.benefits;
-
-    // specialBenefits가 있는 경우 처리
-    if (plan.specialBenefits) {
+  const formatBenefits = (plan: Plan): string[] => {
+    if (plan.mediaAddons && plan.premiumAddons) {
       const services = [
-        ...(plan.specialBenefits.premiumServices || []),
-        ...(plan.specialBenefits.mediaServices || []),
+        ...(plan.mediaAddons || []),
+        ...', ',
+        ...(plan.premiumAddons || []),
       ];
-      return services.map((service) => service.name).join(', ');
+      return services;
+    } else if (plan.mediaAddons) {
+      const services = [...(plan.mediaAddons || [])];
+      return services;
+    } else if (plan.premiumAddons) {
+      const services = [...(plan.premiumAddons || [])];
+      return services;
     }
 
-    return '기본 제공';
+    return ['-'];
   };
 
   return (

--- a/client/src/components/ComparePage/PlanListItem.tsx
+++ b/client/src/components/ComparePage/PlanListItem.tsx
@@ -1,27 +1,7 @@
 import Button from '@/components/common/Button';
 import PlanDetailInfo from './PlanDetailInfo';
 import dropdownIcon from '@/assets/icon/dropdown_icon.svg';
-
-interface Plan {
-  id: string;
-  category: string;
-  name: string;
-  monthlyFee: number;
-  bundleBenefit?: {
-    _id: string;
-    name: string;
-  };
-  basicBenefits?: Array<{
-    _id: string;
-    name: string;
-    description: string;
-  }>;
-  specialBenefits?: {
-    premiumServices: Array<{ _id: string; name: string }>;
-    mediaServices: Array<{ _id: string; name: string }>;
-  };
-  benefits?: string;
-}
+import type { Plan } from '@/components/types/Plan';
 
 interface PlanListItemProps {
   plan: Plan;

--- a/client/src/components/ComparePage/PlanSelectionCard.tsx
+++ b/client/src/components/ComparePage/PlanSelectionCard.tsx
@@ -1,25 +1,5 @@
 import versusIcon from '@/assets/icon/versus_icon.svg';
-
-interface Plan {
-  id: string;
-  category: string;
-  name: string;
-  monthlyFee: number;
-  bundleBenefit?: {
-    _id: string;
-    name: string;
-  };
-  basicBenefits?: Array<{
-    _id: string;
-    name: string;
-    description: string;
-  }>;
-  specialBenefits?: {
-    premiumServices: Array<{ _id: string; name: string }>;
-    mediaServices: Array<{ _id: string; name: string }>;
-  };
-  benefits?: string;
-}
+import type { Plan } from '@/components/types/Plan';
 
 interface PlanSelectionCardProps {
   selectedLeft: Plan | null;
@@ -33,14 +13,26 @@ const PlanSelectionCard: React.FC<PlanSelectionCardProps> = ({
   onSelectSlot,
 }) => {
   return (
-    <div className="flex justify-center mt-[29px]">
-      <div className="flex justify-between w-full max-w-[400px]">
+    <div className="flex justify-center my-[29px]">
+      <div className="flex justify-between w-full">
         <div
           onClick={() => onSelectSlot('left')}
-          className="flex-[2] flex justify-center items-center w-full aspect-square shadow-basic rounded-[17px] cursor-pointer"
+          className={`flex-[2] flex w-full aspect-square rounded-[17px] cursor-pointer bg-background-40 py-4 px-3 justify-center  ${selectedLeft ? 'outline outline-primary-pink flex-col gap-[clamp(0px,2vw,8px)]' : 'shadow-basic items-center '}`}
         >
           {selectedLeft ? (
-            <p>{selectedLeft.name}</p>
+            <>
+              <p className="text-[15px] font-semibold text-gradation w-fit">
+                {selectedLeft.name}
+              </p>
+              <p className="text-xs font-semibold text-gray500 w-fit">
+                {selectedLeft.dataGb === -1
+                  ? '무제한'
+                  : selectedLeft.dataGb + 'GB'}
+              </p>
+              <p className="font-semibold text-primary-pink w-fit">
+                {selectedLeft.monthlyFee.toLocaleString()}원
+              </p>
+            </>
           ) : (
             <p className="text-gradation text-2xl font-semibold text-center">
               요금제
@@ -54,10 +46,22 @@ const PlanSelectionCard: React.FC<PlanSelectionCardProps> = ({
         </div>
         <div
           onClick={() => onSelectSlot('right')}
-          className="flex-[2] flex justify-center items-center w-full aspect-square shadow-basic rounded-[17px] cursor-pointer"
+          className={`flex-[2] flex w-full aspect-square rounded-[17px] cursor-pointer bg-background-40 py-4 px-3 justify-center  ${selectedRight ? 'outline outline-primary-pink flex-col gap-[8px]' : 'shadow-basic items-center '}`}
         >
           {selectedRight ? (
-            <p>{selectedRight.name}</p>
+            <>
+              <p className="text-[15px] font-semibold text-gradation w-fit">
+                {selectedRight.name}
+              </p>
+              <p className="text-xs font-semibold text-gray500 w-fit">
+                {selectedRight.dataGb === -1
+                  ? '무제한'
+                  : selectedRight.dataGb + 'GB'}
+              </p>
+              <p className="font-semibold text-primary-pink w-fit">
+                {selectedRight.monthlyFee.toLocaleString()}원
+              </p>
+            </>
           ) : (
             <p className="text-gradation text-2xl font-semibold text-center">
               요금제

--- a/client/src/components/types/Plan.ts
+++ b/client/src/components/types/Plan.ts
@@ -1,0 +1,21 @@
+export interface Plan {
+  _id: string;
+  category: string;
+  name: string;
+  description?: string;
+  isPopular: boolean;
+  dataGb?: number;
+  sharedDataGb?: number;
+  voiceMinutes?: number;
+  addonVoiceMinutes?: number;
+  smsCount?: number;
+  monthlyFee: number;
+  optionalDiscountAmount?: number;
+  premiumDiscountAmount?: number;
+  ageGroup?: string;
+  detailUrl?: string;
+  bundleBenefit?: string;
+  mediaAddons?: string | null;
+  premiumAddons?: string | null;
+  basicService?: string;
+}

--- a/client/src/hooks/usePlanFilter.ts
+++ b/client/src/hooks/usePlanFilter.ts
@@ -1,25 +1,5 @@
 import { useMemo } from 'react';
-
-interface Plan {
-  id: string;
-  category: string;
-  name: string;
-  monthlyFee: number;
-  bundleBenefit?: {
-    _id: string;
-    name: string;
-  };
-  basicBenefits?: Array<{
-    _id: string;
-    name: string;
-    description: string;
-  }>;
-  specialBenefits?: {
-    premiumServices: Array<{ _id: string; name: string }>;
-    mediaServices: Array<{ _id: string; name: string }>;
-  };
-  benefits?: string;
-}
+import type { Plan } from '@/components/types/Plan';
 
 export const usePlanFilter = (
   plans: Plan[],

--- a/client/src/pages/ComparePage.tsx
+++ b/client/src/pages/ComparePage.tsx
@@ -7,26 +7,8 @@ import PlanListItem from '@/components/ComparePage/PlanListItem';
 import { usePlanFilter } from '@/hooks/usePlanFilter';
 import 'react-spring-bottom-sheet/dist/style.css';
 
-interface Plan {
-  id: string;
-  category: string;
-  name: string;
-  monthlyFee: number;
-  bundleBenefit?: {
-    _id: string;
-    name: string;
-  };
-  basicBenefits?: Array<{
-    _id: string;
-    name: string;
-    description: string;
-  }>;
-  specialBenefits?: {
-    premiumServices: Array<{ _id: string; name: string }>;
-    mediaServices: Array<{ _id: string; name: string }>;
-  };
-  benefits?: string;
-}
+import ComparisonResult from '@/components/ComparePage/ComparisonResult';
+import type { Plan } from '@/components/types/Plan';
 
 const ComparePage: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -51,74 +33,125 @@ const ComparePage: React.FC = () => {
 
   const plans: Plan[] = [
     {
-      id: 'plan1',
+      _id: '1',
+      category: '5G',
+      name: '5G 시그니처',
+      description:
+        'U⁺5G 서비스와 프리미엄 혜택을 마음껏 즐기고, 가족과 공유할 수 있는 데이터까지 추가로 받는 5G 요금제',
+      isPopular: false,
+      dataGb: -1.0,
+      sharedDataGb: 120,
+      voiceMinutes: -1,
+      addonVoiceMinutes: 300,
+      smsCount: -1,
+      monthlyFee: 130000,
+      optionalDiscountAmount: 92250,
+      ageGroup: 'ALL',
+      detailUrl:
+        'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/Z202205253',
+      bundleBenefit:
+        'U+ 투게더 결합, 5G 시그니처 가족할인, 태블릿/스마트기기 월정액 할인, 프리미어 요금제 약정할인, 로밍 혜택 프로모션',
+      mediaAddons:
+        '아이들나라 스탠다드+러닝, 바이브 앱+PC 음악감상, 유플레이, 밀리의 서재, 지니뮤직 앱+PC 음악감상',
+      premiumAddons:
+        '폰교체 패스, 삼성팩, 티빙 이용권 할인, 디즈니+, 넷플릭스, 헬로렌탈구독, 일리커피구독, 우리집지킴이 Easy2+, 우리집돌봄이 Kids, 신한카드 Air, 유튜브 프리미엄 할인',
+      basicService: 'U+ 모바일tv 기본 월정액 무료, U+멤버십 VVIP 등급 혜택',
+    },
+    {
+      _id: '2',
+      category: '5G',
+      name: '5G 프리미어 슈퍼',
+      description:
+        'U⁺5G 서비스와 프리미엄 혜택을 마음껏 즐기고, 가족과 공유할 수 있는 데이터까지 추가로 받는 5G 요금제',
+      isPopular: false,
+      dataGb: -1.0,
+      sharedDataGb: 100,
+      voiceMinutes: -1,
+      addonVoiceMinutes: 300,
+      smsCount: -1,
+      monthlyFee: 115000,
+      optionalDiscountAmount: 81000,
+      ageGroup: 'ALL',
+      detailUrl:
+        'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/Z202205251',
+      bundleBenefit:
+        'U+ 투게더 결합, 태블릿/스마트기기 월정액 할인, 프리미어 요금제 약정할인, 로밍 혜택 프로모션',
+      mediaAddons:
+        '아이들나라 스탠다드+러닝, 유플레이, 밀리의 서재, 지니뮤직 앱+PC 음악감상, 바이브 앱 음악감상',
+      premiumAddons:
+        '폰교체 패스, 삼성팩, 티빙 이용권 할인, 디즈니+, 넷플릭스, 헬로렌탈구독, 일리커피구독, 우리집지킴이 Easy2+, 우리집돌봄이 Kids, 신한카드 Air, 유튜브 프리미엄 할인',
+      basicService: 'U+ 모바일tv 기본 월정액 무료, U+멤버십 VVIP 등급 혜택',
+    },
+    {
+      _id: '3',
       category: '5G',
       name: '5G 프리미어 플러스',
+      description:
+        'U⁺5G 서비스는 물론, 스마트 기기 2개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제',
+      isPopular: false,
+      dataGb: -1.0,
+      sharedDataGb: 100,
+      voiceMinutes: -1,
+      addonVoiceMinutes: 300,
+      smsCount: -1,
       monthlyFee: 105000,
-      bundleBenefit: {
-        _id: 'bundle-01',
-        name: 'U+ 투게더 결합',
-      },
-      basicBenefits: [
-        {
-          _id: 'LPZ0000409',
-          name: 'U+모바일tv 기본 월정액',
-          description:
-            'U⁺오리지널 콘텐츠, 실시간 채널, 해외 드라마, 영화, 등 25만여 편의 동영상 중 내 취향에 맞는 영상을 추천 받아 마음껏 볼 수 있는 앱 서비스',
-        },
-      ],
-      specialBenefits: {
-        premiumServices: [
-          {
-            _id: 'premium-01',
-            name: '삼성팩',
-          },
-          {
-            _id: 'premium-02',
-            name: '티빙',
-          },
-          {
-            _id: 'premium-03',
-            name: '디즈니+',
-          },
-          {
-            _id: 'premium-04',
-            name: '넷플릭스',
-          },
-        ],
-        mediaServices: [
-          {
-            _id: 'media-01',
-            name: '아이들 나라',
-          },
-          {
-            _id: 'media-02',
-            name: '바이브',
-          },
-          {
-            _id: 'media-03',
-            name: '유플레이',
-          },
-          {
-            _id: 'media-04',
-            name: '밀리의 서재',
-          },
-        ],
-      },
+      optionalDiscountAmount: 73500,
+      ageGroup: 'ALL',
+      detailUrl:
+        'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/Z202205252',
+      bundleBenefit:
+        'U+ 투게더 결합, 태블릿/스마트기기 월정액 할인, 프리미어 요금제 약정할인, 로밍 혜택 프로모션',
+      mediaAddons:
+        '아이들나라 스탠다드+러닝, 유플레이, 밀리의 서재, 지니뮤직 앱+PC 음악감상, 바이브 앱 음악감상',
+      premiumAddons:
+        '폰교체 패스, 삼성팩, 티빙 이용권 할인, 넷플릭스, 디즈니+, 헬로렌탈구독, 일리커피구독, 우리집지킴이 Easy2+, 우리집돌봄이 Kids, 신한카드 Air, 유튜브 프리미엄 할인',
+      basicService: 'U+ 모바일tv 기본 월정액 무료, U+멤버십 VVIP 등급 혜택',
     },
     {
-      id: 'plan2',
+      _id: '4',
       category: '5G',
-      name: '5G 레귤러',
+      name: '5G 프리미어 레귤러',
+      description:
+        'U⁺5G 서비스는 물론, 스마트기기 1개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제',
+      isPopular: true,
+      dataGb: -1.0,
+      sharedDataGb: 80,
+      voiceMinutes: -1,
+      addonVoiceMinutes: 300,
+      smsCount: -1,
       monthlyFee: 95000,
-      benefits: '티빙, 디즈니+ 중 택1',
+      optionalDiscountAmount: 66000,
+      ageGroup: 'ALL',
+      detailUrl:
+        'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000433',
+      bundleBenefit:
+        'U+ 투게더 결합, 태블릿/스마트기기 월정액 할인, 프리미어 요금제 약정할인, 로밍 혜택 프로모션',
+      mediaAddons:
+        '아이들나라 스탠다드+러닝, 유플레이, 밀리의 서재, 바이브 300회 음악감상, 지니뮤직 300회 음악감상',
+      premiumAddons: null,
+      basicService: 'U+ 모바일tv 기본 월정액 무료, U+멤버십 VVIP 등급 혜택',
     },
     {
-      id: 'plan3',
-      category: 'LTE',
-      name: 'LTE 라이트',
-      monthlyFee: 45000,
-      benefits: '기본 제공',
+      _id: '5',
+      category: '5G',
+      name: '5G 프리미어 에센셜',
+      description: 'U⁺5G 서비스를 마음껏 즐길 수 있는 5G 요금제',
+      isPopular: true,
+      dataGb: -1.0,
+      sharedDataGb: 70,
+      voiceMinutes: -1,
+      addonVoiceMinutes: 300,
+      smsCount: -1,
+      monthlyFee: 85000,
+      optionalDiscountAmount: 58500,
+      ageGroup: 'ALL',
+      detailUrl:
+        'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000409',
+      bundleBenefit:
+        'U+ 투게더 결합, 태블릿/스마트기기 월정액 할인, 프리미어 요금제 약정할인, 로밍 혜택 프로모션',
+      mediaAddons: null,
+      premiumAddons: null,
+      basicService: 'U+ 모바일tv 기본 월정액 무료, U+멤버십 VIP 등급 혜택',
     },
   ];
 
@@ -141,7 +174,7 @@ const ComparePage: React.FC = () => {
   };
 
   const handleSelectPlan = (plan: Plan) => {
-    if (selectedLeft?.id === plan.id || selectedRight?.id === plan.id) {
+    if (selectedLeft?._id === plan._id || selectedRight?._id === plan._id) {
       return;
     }
 
@@ -185,7 +218,12 @@ const ComparePage: React.FC = () => {
         onSelectSlot={openSheetForSlot}
       />
 
-      {!hasSelectedPlans && (
+      {hasSelectedPlans ? (
+        <ComparisonResult
+          selectedLeft={selectedLeft}
+          selectedRight={selectedRight}
+        />
+      ) : (
         <div className="flex flex-col justify-center items-center text-center text-gray500 mt-[120px]">
           <p className="text-lg">비교할 요금제가 없습니다</p>
           <p className="text-xl">버튼을 눌러 요금제를 선택해주세요!</p>
@@ -210,13 +248,14 @@ const ComparePage: React.FC = () => {
           <div className="flex flex-col gap-[15px] select-none pt-[190px] mb-3">
             {filteredPlans.map((plan) => (
               <PlanListItem
-                key={plan.id}
+                key={plan._id}
                 plan={plan}
-                isOpen={openDropdowns[plan.id] || false}
+                isOpen={openDropdowns[plan._id] || false}
                 isDisabled={
-                  selectedLeft?.id === plan.id || selectedRight?.id === plan.id
+                  selectedLeft?._id === plan._id ||
+                  selectedRight?._id === plan._id
                 }
-                onToggle={() => toggleDropdown(plan.id)}
+                onToggle={() => toggleDropdown(plan._id)}
                 onSelect={() => handleSelectPlan(plan)}
               />
             ))}


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 요금제 타입 공통 Plan 타입으로 통합 및 import로 변경
2. 요금제 선택 카드에 데이터/요금 표시 추가
3. 데이터 비교 막대 그래프 구현
4. 혜택(결합, 프리미엄, 미디어) 비교용 컴포넌트 구현
5. 요금제 비교 페이지 자세히 보기 버튼 구현

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 요금제 카드 선택한 경우 기존 이름만 표시되던 부분 이름/데이터/요금 표시되도록 변경
- 데이터 비교 막대 그래프는 선택된 요금제 중 데이터 용량이 더 큰 값을 기준(Max)으로 설정하고, 작은 값은 이 기준 대비 비율로 길이를 계산함 (예: 100GB vs 10GB 선택 시, 그래프 길이는 각각 100%, 10%로 표시), 무제한은 300GB 설정
- **혜택 비교 시 미디어 서비스에 대한 이미지 필요, 프리미엄 서비스 이미지도 바꿔야 할 수도 있을것같음**
- 자세히 보기 클릭 시 실제 유플러스 요금제 홈페이지 이동 버튼 구현


## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![chrome-capture-2025-6-19](https://github.com/user-attachments/assets/d7e2afe0-ecdf-4335-8f9d-3df68d04da62)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨