### PR TITLE
Design/모달 및 드롭다운 UI 변경

### DIFF
--- a/client/src/components/ComparePage/PlanDetailInfo.tsx
+++ b/client/src/components/ComparePage/PlanDetailInfo.tsx
@@ -1,10 +1,17 @@
 import type { Plan } from '@/components/types/Plan';
+import Button from '../common/Button';
 
 interface PlanDetailInfoProps {
   plan: Plan;
+  onClick?: () => void;
+  disabled?: boolean;
 }
 
-const PlanDetailInfo: React.FC<PlanDetailInfoProps> = ({ plan }) => {
+const PlanDetailInfo: React.FC<PlanDetailInfoProps> = ({
+  plan,
+  onClick,
+  disabled,
+}) => {
   const formatBenefits = (plan: Plan): string[] => {
     if (plan.mediaAddons && plan.premiumAddons) {
       const services = [
@@ -45,6 +52,12 @@ const PlanDetailInfo: React.FC<PlanDetailInfoProps> = ({ plan }) => {
       <div className="flex gap-[5px]">
         <p className="min-w-[64px] text-secondary-purple-80">부가서비스</p>
         <p>{formatBenefits(plan)}</p>
+      </div>
+
+      <div className="h-[43px] mt-2">
+        <Button onClick={onClick} disabled={disabled}>
+          선택하기
+        </Button>
       </div>
     </div>
   );

--- a/client/src/components/ComparePage/PlanListItem.tsx
+++ b/client/src/components/ComparePage/PlanListItem.tsx
@@ -1,4 +1,3 @@
-import Button from '@/components/common/Button';
 import PlanDetailInfo from './PlanDetailInfo';
 import dropdownIcon from '@/assets/icon/dropdown_icon.svg';
 import type { Plan } from '@/components/types/Plan';
@@ -35,12 +34,11 @@ const PlanListItem: React.FC<PlanListItemProps> = ({
       </div>
       {isOpen && (
         <>
-          <PlanDetailInfo plan={plan} />
-          <div className="h-[43px] mt-2">
-            <Button onClick={onSelect} disabled={isDisabled}>
-              선택하기
-            </Button>
-          </div>
+          <PlanDetailInfo
+            plan={plan}
+            onClick={onSelect}
+            disabled={isDisabled}
+          />
         </>
       )}
     </div>

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -3,6 +3,7 @@ interface ButtonProps {
   children: React.ReactNode;
   onClick?: () => void;
   disabled?: boolean;
+  isModal?: boolean;
 }
 
 const colorClasses: Record<string, string> = {
@@ -15,6 +16,7 @@ const Button: React.FC<ButtonProps> = ({
   children = '계속할래요',
   onClick,
   disabled = false,
+  isModal = false,
 }) => {
   return (
     <button
@@ -22,6 +24,7 @@ const Button: React.FC<ButtonProps> = ({
       disabled={disabled}
       className={`
         px-4 py-[9px] rounded-[10px] font-semibold w-full text-sm
+        ${isModal ? 'h-[42px]' : 'h-full'}
         ${colorClasses[color] || colorClasses.primary}
         ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:cursor-pointer'}
       `}

--- a/client/src/pages/ComparePage.tsx
+++ b/client/src/pages/ComparePage.tsx
@@ -9,6 +9,9 @@ import 'react-spring-bottom-sheet/dist/style.css';
 
 import ComparisonResult from '@/components/ComparePage/ComparisonResult';
 import type { Plan } from '@/components/types/Plan';
+import Modal from '@/components/common/Modal';
+import Button from '@/components/common/Button';
+import { useNavigate } from 'react-router-dom';
 
 const ComparePage: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -22,6 +25,9 @@ const ComparePage: React.FC = () => {
   const [selectedSlot, setSelectedSlot] = useState<'left' | 'right' | null>(
     null,
   );
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const navigate = useNavigate();
 
   const dataList = ['전체', '5G', 'LTE'];
   const priceList = [
@@ -201,11 +207,33 @@ const ComparePage: React.FC = () => {
     }));
   };
 
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
   const hasSelectedPlans = selectedLeft && selectedRight;
 
   return (
     <>
-      <Header title="요금제 비교하기" />
+      <Header title="요금제 비교하기" onBackClick={() => openModal()} />
+      {isModalOpen && (
+        <Modal
+          isOpen={isModalOpen}
+          onClose={closeModal}
+          modalTitle="요금제 비교하기를 그만두시겠어요?"
+          modalDesc="그만두실 경우, 선택하신 요금제가 모두 초기화됩니다."
+        >
+          <Button color="secondary" isModal onClick={closeModal}>
+            계속할래요
+          </Button>
+          <Button isModal onClick={() => navigate('/')}>
+            그만둘래요
+          </Button>
+        </Modal>
+      )}
       <h1 className="font-semibold text-2xl text-center mt-[20px]">
         비교하고 싶은
         <br />


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 요금제 선택하기 버튼 위치 수정
2. 요금제 선택 페이지 뒤로가기 클릭 시 모달 적용
3. 공통 버튼 컴포넌트 모달 구분 prop 적용

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 요금제 비교 페이지에서 선택하기 버튼이 박스 바깥으로 나와있던 부분을 안쪽으로 들어오도록 수정
- 공통 버튼 컴포넌트에 isModal prop을 추가하여 모달 버튼인 경우 일정 높이로 적용하도록 구현

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

![image](https://github.com/user-attachments/assets/23785dbc-0400-4dca-891d-33d074767593)
변경 전(선택하기 버튼이 요금제 정보 박스 바깥에 위치함) 

![image](https://github.com/user-attachments/assets/9b234534-d4a2-42ca-9865-94d533b49b0f)
변경 후(선택하기 버튼이 요금제 정보 박스 안에 위치함)


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
