### PR TITLE
Feat/요금제비교 단일선택 기능 추가

### DIFF
--- a/client/src/assets/icon/close.svg
+++ b/client/src/assets/icon/close.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.3032 8.6968L7.0006 7M7.0006 7L8.6974 5.3032M7.0006 7L5.3032 5.3032M7.0006 7L8.6974 8.6968M7 13C10.3138 13 13 10.3138 13 7C13 3.6862 10.3138 1 7 1C3.6862 1 1 3.6862 1 7C1 10.3138 3.6862 13 7 13Z" stroke="#717379" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/components/ComparePage/ComparisonActionButtons.tsx
+++ b/client/src/components/ComparePage/ComparisonActionButtons.tsx
@@ -1,6 +1,6 @@
 interface ComparisonActionButtonsProps {
-  leftButtonText: string;
-  rightButtonText: string;
+  leftButtonText?: string;
+  rightButtonText?: string;
   onLeftClick: () => void;
   onRightClick: () => void;
 }
@@ -13,26 +13,30 @@ const ComparisonActionButtons: React.FC<ComparisonActionButtonsProps> = ({
 }) => {
   return (
     <div
-      className="flex flex-col justify-center items-center text-center gap-6 fixed bottom-[29px] max-w-[560px] overflow-visible h-[106px]"
+      className="flex flex-col justify-center items-center text-center gap-6 fixed bottom-[24px] max-w-[560px] h-[116px]"
       style={{ width: 'calc(100% - 40px)' }}
     >
-      <div className="flex w-full overflow-visible">
-        <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center rounded-[10px] shadow-basic">
-          <button
-            onClick={onLeftClick}
-            className="text-xs text-background-40 font-semibold bg-primary-pink w-full h-[38px] flex items-center justify-center rounded-[10px] cursor-pointer shadow-basic"
-          >
-            {leftButtonText}
-          </button>
+      <div className="flex w-full">
+        <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center rounded-[10px]">
+          {leftButtonText && (
+            <button
+              onClick={onLeftClick}
+              className="text-xs text-background-40 font-semibold bg-primary-pink w-full h-[38px] flex items-center justify-center rounded-[10px] cursor-pointer shadow-basic"
+            >
+              {leftButtonText}
+            </button>
+          )}
         </div>
         <div className="flex-[1] text-sm flex items-center justify-center" />
-        <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center rounded-[10px] shadow-basic">
-          <button
-            onClick={onRightClick}
-            className="text-xs text-background-40 font-semibold bg-primary-pink w-full h-[38px] flex items-center justify-center rounded-[10px] cursor-pointer shadow-basic"
-          >
-            {rightButtonText}
-          </button>
+        <div className="flex-[2] relative flex flex-col items-center gap-1 justify-center rounded-[10px]">
+          {rightButtonText && (
+            <button
+              onClick={onRightClick}
+              className="text-xs text-background-40 font-semibold bg-primary-pink w-full h-[38px] flex items-center justify-center rounded-[10px] cursor-pointer shadow-basic"
+            >
+              {rightButtonText}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/ComparePage/ComparisonResult.tsx
+++ b/client/src/components/ComparePage/ComparisonResult.tsx
@@ -21,50 +21,45 @@ const ComparisonResult: React.FC<ComparisonResultProps> = ({
     }
   };
 
-  // 선택된 요금제가 있는지 확인
-  const hasLeftPlan = selectedLeft !== null;
-  const hasRightPlan = selectedRight !== null;
-  const hasBothPlans = hasLeftPlan && hasRightPlan;
-
   // 데이터 값 계산
-  const leftDataValue = hasLeftPlan
+  const leftDataValue = selectedLeft
     ? selectedLeft.dataGb === -1
       ? 300
       : selectedLeft.dataGb || 0
     : 0;
-  const rightDataValue = hasRightPlan
+  const rightDataValue = selectedRight
     ? selectedRight.dataGb === -1
       ? 300
       : selectedRight.dataGb || 0
     : 0;
-  const leftSharedDataValue = hasLeftPlan
+  const leftSharedDataValue = selectedLeft
     ? selectedLeft.sharedDataGb === -1
       ? 300
       : selectedLeft.sharedDataGb || 0
     : 0;
-  const rightSharedDataValue = hasRightPlan
+  const rightSharedDataValue = selectedRight
     ? selectedRight.sharedDataGb === -1
       ? 300
       : selectedRight.sharedDataGb || 0
     : 0;
 
   // 데이터 라벨 계산
-  const leftDataLabel = hasLeftPlan
+  const leftDataLabel = selectedLeft
     ? selectedLeft.dataGb === -1
       ? '무제한'
       : `${selectedLeft.dataGb}GB`
     : '';
-  const rightDataLabel = hasRightPlan
+  const rightDataLabel = selectedRight
     ? selectedRight.dataGb === -1
       ? '무제한'
       : `${selectedRight.dataGb}GB`
     : '';
-  const leftSharedDataLabel = hasLeftPlan
+  const leftSharedDataLabel = selectedLeft
     ? selectedLeft.sharedDataGb === -1
       ? '무제한'
       : `${selectedLeft.sharedDataGb}GB`
     : '';
-  const rightSharedDataLabel = hasRightPlan
+  const rightSharedDataLabel = selectedRight
     ? selectedRight.sharedDataGb === -1
       ? '무제한'
       : `${selectedRight.sharedDataGb}GB`
@@ -145,8 +140,8 @@ const ComparisonResult: React.FC<ComparisonResultProps> = ({
       </div>
 
       <ComparisonActionButtons
-        leftButtonText={hasLeftPlan ? '자세히 보기' : ''}
-        rightButtonText={hasRightPlan ? '자세히 보기' : ''}
+        leftButtonText={selectedLeft ? '자세히 보기' : ''}
+        rightButtonText={selectedRight ? '자세히 보기' : ''}
         onLeftClick={() => handleDetailClick(selectedLeft?.detailUrl)}
         onRightClick={() => handleDetailClick(selectedRight?.detailUrl)}
       />

--- a/client/src/components/ComparePage/ComparisonResult.tsx
+++ b/client/src/components/ComparePage/ComparisonResult.tsx
@@ -7,8 +7,8 @@ import mediaAddonsIcon from '@/assets/icon/media.png';
 import type { Plan } from '@/components/types/Plan';
 
 interface ComparisonResultProps {
-  selectedLeft: Plan;
-  selectedRight: Plan;
+  selectedLeft: Plan | null;
+  selectedRight: Plan | null;
 }
 
 const ComparisonResult: React.FC<ComparisonResultProps> = ({
@@ -21,27 +21,54 @@ const ComparisonResult: React.FC<ComparisonResultProps> = ({
     }
   };
 
-  const leftDataValue =
-    selectedLeft?.dataGb === -1 ? 300 : selectedLeft?.dataGb || 0;
-  const rightDataValue =
-    selectedRight?.dataGb === -1 ? 300 : selectedRight?.dataGb || 0;
-  const leftSharedDataValue =
-    selectedLeft?.sharedDataGb === -1 ? 300 : selectedLeft?.sharedDataGb || 0;
-  const rightSharedDataValue =
-    selectedRight?.sharedDataGb === -1 ? 300 : selectedRight?.sharedDataGb || 0;
+  // 선택된 요금제가 있는지 확인
+  const hasLeftPlan = selectedLeft !== null;
+  const hasRightPlan = selectedRight !== null;
+  const hasBothPlans = hasLeftPlan && hasRightPlan;
 
-  const leftDataLabel =
-    selectedLeft.dataGb === -1 ? '무제한' : `${selectedLeft.dataGb}GB`;
-  const rightDataLabel =
-    selectedRight.dataGb === -1 ? '무제한' : `${selectedRight.dataGb}GB`;
-  const leftSharedDataLabel =
-    selectedLeft.sharedDataGb === -1
+  // 데이터 값 계산
+  const leftDataValue = hasLeftPlan
+    ? selectedLeft.dataGb === -1
+      ? 300
+      : selectedLeft.dataGb || 0
+    : 0;
+  const rightDataValue = hasRightPlan
+    ? selectedRight.dataGb === -1
+      ? 300
+      : selectedRight.dataGb || 0
+    : 0;
+  const leftSharedDataValue = hasLeftPlan
+    ? selectedLeft.sharedDataGb === -1
+      ? 300
+      : selectedLeft.sharedDataGb || 0
+    : 0;
+  const rightSharedDataValue = hasRightPlan
+    ? selectedRight.sharedDataGb === -1
+      ? 300
+      : selectedRight.sharedDataGb || 0
+    : 0;
+
+  // 데이터 라벨 계산
+  const leftDataLabel = hasLeftPlan
+    ? selectedLeft.dataGb === -1
       ? '무제한'
-      : `${selectedLeft.sharedDataGb}GB`;
-  const rightSharedDataLabel =
-    selectedRight.sharedDataGb === -1
+      : `${selectedLeft.dataGb}GB`
+    : '';
+  const rightDataLabel = hasRightPlan
+    ? selectedRight.dataGb === -1
       ? '무제한'
-      : `${selectedRight.sharedDataGb}GB`;
+      : `${selectedRight.dataGb}GB`
+    : '';
+  const leftSharedDataLabel = hasLeftPlan
+    ? selectedLeft.sharedDataGb === -1
+      ? '무제한'
+      : `${selectedLeft.sharedDataGb}GB`
+    : '';
+  const rightSharedDataLabel = hasRightPlan
+    ? selectedRight.sharedDataGb === -1
+      ? '무제한'
+      : `${selectedRight.sharedDataGb}GB`
+    : '';
 
   return (
     <>
@@ -53,6 +80,7 @@ const ComparisonResult: React.FC<ComparisonResultProps> = ({
             leftLabel={leftDataLabel}
             rightLabel={rightDataLabel}
             title="데이터"
+            // showComparison={hasBothPlans}
           />
           <DataComparisonBar
             leftValue={leftSharedDataValue}
@@ -60,6 +88,7 @@ const ComparisonResult: React.FC<ComparisonResultProps> = ({
             leftLabel={leftSharedDataLabel}
             rightLabel={rightSharedDataLabel}
             title="공유 데이터"
+            // showComparison={hasBothPlans}
           />
         </div>
 
@@ -67,59 +96,59 @@ const ComparisonResult: React.FC<ComparisonResultProps> = ({
 
         <div className="flex flex-col justify-center items-center text-center w-full gap-6 mb-[106px]">
           <BenefitComparisonRow
-            leftContent={selectedLeft.bundleBenefit || null}
-            rightContent={selectedRight.bundleBenefit || null}
+            leftContent={selectedLeft?.bundleBenefit || null}
+            rightContent={selectedRight?.bundleBenefit || null}
             title="결합 할인"
-            leftIcon={selectedLeft.bundleBenefit ? togetherIcon : undefined}
-            rightIcon={selectedRight.bundleBenefit ? togetherIcon : undefined}
+            leftIcon={selectedLeft?.bundleBenefit ? togetherIcon : undefined}
+            rightIcon={selectedRight?.bundleBenefit ? togetherIcon : undefined}
             iconAlt="togetherIcon"
           />
 
           <BenefitComparisonRow
             leftContent={
-              selectedLeft.premiumAddons
-                ? `(택1) ${selectedLeft.premiumAddons}`
+              selectedLeft?.premiumAddons
+                ? `(택1) ${selectedLeft?.premiumAddons}`
                 : null
             }
             rightContent={
-              selectedRight.premiumAddons
-                ? `(택1) ${selectedRight.premiumAddons}`
+              selectedRight?.premiumAddons
+                ? `(택1) ${selectedRight?.premiumAddons}`
                 : null
             }
             title="프리미엄 서비스"
             leftIcon={
-              selectedLeft.premiumAddons ? premiumAddonsIcon : undefined
+              selectedLeft?.premiumAddons ? premiumAddonsIcon : undefined
             }
             rightIcon={
-              selectedRight.premiumAddons ? premiumAddonsIcon : undefined
+              selectedRight?.premiumAddons ? premiumAddonsIcon : undefined
             }
             iconAlt="premiumIcon"
           />
 
           <BenefitComparisonRow
             leftContent={
-              selectedLeft.mediaAddons
-                ? `(택1) ${selectedLeft.mediaAddons}`
+              selectedLeft?.mediaAddons
+                ? `(택1) ${selectedLeft?.mediaAddons}`
                 : null
             }
             rightContent={
-              selectedRight.mediaAddons
-                ? `(택1) ${selectedRight.mediaAddons}`
+              selectedRight?.mediaAddons
+                ? `(택1) ${selectedRight?.mediaAddons}`
                 : null
             }
             title="미디어 서비스"
-            leftIcon={selectedLeft.mediaAddons ? mediaAddonsIcon : undefined}
-            rightIcon={selectedRight.mediaAddons ? mediaAddonsIcon : undefined}
+            leftIcon={selectedLeft?.mediaAddons ? mediaAddonsIcon : undefined}
+            rightIcon={selectedRight?.mediaAddons ? mediaAddonsIcon : undefined}
             iconAlt="premiumIcon"
           />
         </div>
       </div>
 
       <ComparisonActionButtons
-        leftButtonText="자세히 보기"
-        rightButtonText="자세히 보기"
-        onLeftClick={() => handleDetailClick(selectedLeft.detailUrl)}
-        onRightClick={() => handleDetailClick(selectedRight.detailUrl)}
+        leftButtonText={hasLeftPlan ? '자세히 보기' : ''}
+        rightButtonText={hasRightPlan ? '자세히 보기' : ''}
+        onLeftClick={() => handleDetailClick(selectedLeft?.detailUrl)}
+        onRightClick={() => handleDetailClick(selectedRight?.detailUrl)}
       />
     </>
   );

--- a/client/src/components/ComparePage/DataComparisonBar.tsx
+++ b/client/src/components/ComparePage/DataComparisonBar.tsx
@@ -21,7 +21,7 @@ const DataComparisonBar: React.FC<DataComparisonBarProps> = ({
     <div className="flex w-full">
       <div className="flex-[2] relative flex flex-col items-end gap-1">
         <div
-          className="bg-gradation rounded-l-full h-5"
+          className="bg-gradation rounded-l-full h-5 transition-all duration-800"
           style={{ width: `${leftRatio}%` }}
         />
         <div className="text-xs text-gray500">{leftLabel}</div>
@@ -29,7 +29,7 @@ const DataComparisonBar: React.FC<DataComparisonBarProps> = ({
       <div className="flex-[1] text-sm">{title}</div>
       <div className="flex-[2] relative flex flex-col items-start gap-1">
         <div
-          className="bg-gradation rounded-r-full h-5"
+          className="bg-gradation rounded-r-full h-5 transition-all duration-800"
           style={{ width: `${rightRatio}%` }}
         />
         <div className="text-xs text-gray500">{rightLabel}</div>

--- a/client/src/components/ComparePage/PlanSelectionCard.tsx
+++ b/client/src/components/ComparePage/PlanSelectionCard.tsx
@@ -1,26 +1,38 @@
 import versusIcon from '@/assets/icon/versus_icon.svg';
+import closeIcon from '@/assets/icon/close.svg';
 import type { Plan } from '@/components/types/Plan';
 
 interface PlanSelectionCardProps {
   selectedLeft: Plan | null;
   selectedRight: Plan | null;
   onSelectSlot: (slot: 'left' | 'right') => void;
+  onClearSlot: (slot: 'left' | 'right') => void;
 }
 
 const PlanSelectionCard: React.FC<PlanSelectionCardProps> = ({
   selectedLeft,
   selectedRight,
   onSelectSlot,
+  onClearSlot,
 }) => {
   return (
     <div className="flex justify-center my-[29px]">
       <div className="flex justify-between w-full">
         <div
           onClick={() => onSelectSlot('left')}
-          className={`flex-[2] flex w-full aspect-square rounded-[17px] cursor-pointer bg-background-40 py-4 px-3 justify-center  ${selectedLeft ? 'outline outline-primary-pink flex-col gap-[clamp(0px,2vw,8px)]' : 'shadow-basic items-center '}`}
+          className={`relative flex-[2] flex w-full aspect-square rounded-[17px] cursor-pointer bg-background-40 py-4 px-3 justify-center  ${selectedLeft ? 'outline outline-primary-pink flex-col gap-[clamp(0px,2vw,8px)]' : 'shadow-basic items-center '}`}
         >
           {selectedLeft ? (
             <>
+              <div
+                className="absolute top-0 right-0 p-[10px]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClearSlot('left');
+                }}
+              >
+                <img src={closeIcon} alt="closeIcon" className="w-4 h-4" />
+              </div>
               <p className="text-[15px] font-semibold text-gradation w-fit">
                 {selectedLeft.name}
               </p>
@@ -46,10 +58,19 @@ const PlanSelectionCard: React.FC<PlanSelectionCardProps> = ({
         </div>
         <div
           onClick={() => onSelectSlot('right')}
-          className={`flex-[2] flex w-full aspect-square rounded-[17px] cursor-pointer bg-background-40 py-4 px-3 justify-center  ${selectedRight ? 'outline outline-primary-pink flex-col gap-[8px]' : 'shadow-basic items-center '}`}
+          className={`relative flex-[2] flex w-full aspect-square rounded-[17px] cursor-pointer bg-background-40 py-4 px-3 justify-center  ${selectedRight ? 'outline outline-primary-pink flex-col gap-[8px]' : 'shadow-basic items-center '}`}
         >
           {selectedRight ? (
             <>
+              <div
+                className="absolute top-0 right-0 p-[10px]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClearSlot('right');
+                }}
+              >
+                <img src={closeIcon} alt="closeIcon" className="w-4 h-4" />
+              </div>
               <p className="text-[15px] font-semibold text-gradation w-fit">
                 {selectedRight.name}
               </p>

--- a/client/src/pages/ComparePage.tsx
+++ b/client/src/pages/ComparePage.tsx
@@ -200,6 +200,14 @@ const ComparePage: React.FC = () => {
     setOpen(true);
   };
 
+  const handleClearSlot = (slot: 'left' | 'right') => {
+    if (slot === 'left') {
+      setSelectedLeft(null);
+    } else if (slot === 'right') {
+      setSelectedRight(null);
+    }
+  };
+
   const toggleDropdown = (id: string) => {
     setOpenDropdowns((prev) => ({
       ...prev,
@@ -244,9 +252,20 @@ const ComparePage: React.FC = () => {
         selectedLeft={selectedLeft}
         selectedRight={selectedRight}
         onSelectSlot={openSheetForSlot}
+        onClearSlot={handleClearSlot}
       />
-
-      {hasSelectedPlans ? (
+      {/* {hasSelectedPlans ? (
+        <ComparisonResult
+          selectedLeft={selectedLeft}
+          selectedRight={selectedRight}
+        />
+      ) : (
+        <div className="flex flex-col justify-center items-center text-center text-gray500 mt-[120px]">
+          <p className="text-lg">비교할 요금제가 없습니다</p>
+          <p className="text-xl">버튼을 눌러 요금제를 선택해주세요!</p>
+        </div>
+      )} */}
+      {selectedLeft || selectedRight ? (
         <ComparisonResult
           selectedLeft={selectedLeft}
           selectedRight={selectedRight}
@@ -257,7 +276,6 @@ const ComparePage: React.FC = () => {
           <p className="text-xl">버튼을 눌러 요금제를 선택해주세요!</p>
         </div>
       )}
-
       <BottomSheet
         open={open}
         onDismiss={() => setOpen(false)}

--- a/client/src/pages/ComparePage.tsx
+++ b/client/src/pages/ComparePage.tsx
@@ -222,8 +222,6 @@ const ComparePage: React.FC = () => {
     setIsModalOpen(false);
   };
 
-  const hasSelectedPlans = selectedLeft && selectedRight;
-
   return (
     <>
       <Header title="요금제 비교하기" onBackClick={() => openModal()} />
@@ -254,17 +252,6 @@ const ComparePage: React.FC = () => {
         onSelectSlot={openSheetForSlot}
         onClearSlot={handleClearSlot}
       />
-      {/* {hasSelectedPlans ? (
-        <ComparisonResult
-          selectedLeft={selectedLeft}
-          selectedRight={selectedRight}
-        />
-      ) : (
-        <div className="flex flex-col justify-center items-center text-center text-gray500 mt-[120px]">
-          <p className="text-lg">비교할 요금제가 없습니다</p>
-          <p className="text-xl">버튼을 눌러 요금제를 선택해주세요!</p>
-        </div>
-      )} */}
       {selectedLeft || selectedRight ? (
         <ComparisonResult
           selectedLeft={selectedLeft}


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 요금제 비교 선택 취소 버튼 추가
2. 단일 선택 기능 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 요금제 선택을 취소할 수 있는 버튼 기능 추가
- 기존에는 요금제를 둘 다 선택해야 비교가 가능했지만 하나만 선택해도 정보를 볼 수 있도록 수정

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

![image](https://github.com/user-attachments/assets/afd5a342-f322-4bcf-b6c5-a2208608f2a0)
변경 전(요금제 둘 다 선택해야 정보 확인 가능)

![image](https://github.com/user-attachments/assets/f352061a-6308-4725-8e6e-46069ecf72b5)
변경 후(요금제 하나만 선택해도 정보 확인 가능, 선택 취소 버튼 추가)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
