### PR TITLE
Feat/답변선택시 아이콘 비활성화

### DIFF
--- a/client/src/pages/TestPage.tsx
+++ b/client/src/pages/TestPage.tsx
@@ -18,6 +18,7 @@ import { useRef } from 'react';
 const TestPage = () => {
   const navigate = useNavigate();
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isTransitioning, setIsTransitioning] = useState(false);
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedOptions, setSelectedOptions] = useState<{
@@ -40,6 +41,7 @@ const TestPage = () => {
 
   const handleSelect = (value: string) => {
     setSelectedOptions((prev) => ({ ...prev, [currentQuestion.id]: value }));
+    setIsTransitioning(true);
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
@@ -48,6 +50,7 @@ const TestPage = () => {
       if (currentIndex < questions.length - 1) {
         setCurrentIndex((prev) => prev + 1);
       }
+      setIsTransitioning(false);
     }, 1000);
   };
 
@@ -94,7 +97,7 @@ const TestPage = () => {
 
             <button
               onClick={handleBack}
-              disabled={currentIndex === 0}
+              disabled={currentIndex === 0 || isTransitioning}
               className="absolute left-0 top-1/2 -translate-y-1/2"
             >
               <img src={back} alt="이전질문" className="w-[8px] h-[16px]" />
@@ -102,7 +105,9 @@ const TestPage = () => {
 
             <button
               onClick={handleNext}
-              disabled={currentIndex === questions.length - 1}
+              disabled={
+                currentIndex === questions.length - 1 || isTransitioning
+              }
               className="absolute right-0 top-1/2 -translate-y-1/2"
             >
               <img src={next} alt="다음질문" className="w-[8px] h-[16px]" />


### PR DESCRIPTION
## 📝 변경 사항

Feat/답변선택시 아이콘 비활성화

## 🔍 변경 사항 세부 설명

- 사용자가 답변을 선택하면 자동으로 1.5초 후 넘어가고 이전,다음질문으로 가는 버튼은 비활성화 처리됩니다.
- 답변을선택하여 다음질문으로 이동하면 이전, 다음 버튼은 활성화됩니다.

## 🕵️‍♀️ 요청사항

-dev받아주세요~

## 📷 스크린샷 (선택)
![Animation](https://github.com/user-attachments/assets/5835bb7e-9a2a-43fb-ae3f-5b7be495533c)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
