### PR TITLE
Feat : 요금제 추천 페이지 API 연동 및 불필요한 코드 정리

### DIFF
--- a/client/src/api/testPlan.ts
+++ b/client/src/api/testPlan.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_API_BASE_URL;
+
+export const getAllPlans = async () => {
+  const response = await axios.get(`${baseURL}/api/plan/explore`);
+  return response.data;
+};

--- a/client/src/components/types/TestResult.ts
+++ b/client/src/components/types/TestResult.ts
@@ -1,6 +1,7 @@
 export type Answer = string;
 
 export type PlanResult = {
+  _id: string;
   id: string;
   name: string;
   description: string;
@@ -11,4 +12,5 @@ export type PlanResult = {
   price: number;
   tagLine?: string;
   link: string;
+  isActive: boolean;
 };

--- a/client/src/data/TestResult.ts
+++ b/client/src/data/TestResult.ts
@@ -1,22 +1,8 @@
 import type { PlanResult } from '@/components/types/TestResult';
 
 export const planResults: PlanResult[] = [
-  //음악
   {
-    id: 'music-plus',
-    name: '5G 프리미어 레귤러',
-    description:
-      'U⁺5G 서비스는 물론, 스마트기기 1개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제\n미디어 서비스 기본 제공(택1)\n지니, 벅스, FLO 중 선택 가능',
-    priority: 3,
-    dataUsage: 100,
-    callUsage: 100,
-    messageUsage: 100,
-    price: 95000,
-    tagLine: '지니뮤직 제휴 결합',
-    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000433',
-  },
-  //OTT
-  {
+    _id: '6858ee7ffc03f10c86710103',
     id: 'ott-plus',
     name: '5G 프리미어 플러스',
     description:
@@ -28,23 +14,10 @@ export const planResults: PlanResult[] = [
     price: 105000,
     tagLine: '넷플릭스 / 왓챠 제휴 결합',
     link: 'https://www.lguplus.com/plan/limit-plans/Z202205254',
+    isActive: true,
   },
-  //결합
   {
-    id: 'family',
-    name: '5G 프리미어 에센셜',
-    description:
-      'U⁺5G 서비스를 마음껏 즐길 수 있는 5G 요금제\n친구, 가족과 결합하면 데이터 무제한 요금제를 최대 20,000원 할인',
-    priority: 4,
-    dataUsage: 100,
-    callUsage: 100,
-    messageUsage: 100,
-    price: 85000,
-    tagLine: 'U+ 투게더 결합',
-    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000409',
-  },
-  // 청소년
-  {
+    _id: '6858ee7ffc03f10c86710105',
     id: 'youth1-special',
     name: '5G 라이트 청소년',
     description:
@@ -56,9 +29,10 @@ export const planResults: PlanResult[] = [
     price: 45000,
     tagLine: '데이터 무제한 최대 1Mbps 속도',
     link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-youth/LPZ0000417',
+    isActive: true,
   },
-  //유스
   {
+    _id: '6858ee7ffc03f10c86710106',
     id: 'youth2-special',
     name: '유스 5G 스탠다드',
     description:
@@ -70,9 +44,10 @@ export const planResults: PlanResult[] = [
     price: 75000,
     tagLine: '데이터 무제한 최대 5Mbps 속도',
     link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-young/LPZ1000232',
+    isActive: true,
   },
-  //시니어
   {
+    _id: '6858ee7ffc03f10c86710107',
     id: 'youth3-special',
     name: 'LTE 데이터 시니어 33',
     description:
@@ -84,9 +59,55 @@ export const planResults: PlanResult[] = [
     price: 33000,
     tagLine: '실버지킴이 서비스',
     link: 'https://www.lguplus.com/mobile/plan/mplan/lte-all/lte-senior/LPZ0000296',
+    isActive: true,
   },
-  //무제한데이터
   {
+    _id: '6858ee7ffc03f10c86710103',
+    id: 'ott-plus',
+    name: '5G 프리미어 플러스',
+    description:
+      'U⁺5G 서비스는 물론, 스마트 기기 2개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제\n프리미엄 서비스 기본 제공(택1)\n음악 구독 서비스 지니, 벅스, FLO 중 선택 가능',
+    priority: 2,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 105000,
+    tagLine: '넷플릭스 / 왓챠 제휴 결합',
+    link: 'https://www.lguplus.com/plan/limit-plans/Z202205254',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710102',
+    id: 'music-plus',
+    name: '5G 프리미어 레귤러',
+    description:
+      'U⁺5G 서비스는 물론, 스마트기기 1개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제\n미디어 서비스 기본 제공(택1)\n지니, 벅스, FLO 중 선택 가능',
+    priority: 3,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 95000,
+    tagLine: '지니뮤직 제휴 결합',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000433',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710104',
+    id: 'family',
+    name: '5G 프리미어 에센셜',
+    description:
+      'U⁺5G 서비스를 마음껏 즐길 수 있는 5G 요금제\n친구, 가족과 결합하면 데이터 무제한 요금제를 최대 20,000원 할인',
+    priority: 4,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 85000,
+    tagLine: 'U+ 투게더 결합',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000409',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710108',
     id: 'max-data',
     name: '5G 프리미어 에센셜',
     description:
@@ -98,9 +119,10 @@ export const planResults: PlanResult[] = [
     price: 85000,
     tagLine: '데이터 무제한',
     link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000409',
+    isActive: true,
   },
-  //고용량데이터
   {
+    _id: '6858ee7ffc03f10c86710109',
     id: 'data-high',
     name: '5G 스탠다드',
     description:
@@ -112,9 +134,10 @@ export const planResults: PlanResult[] = [
     price: 75000,
     tagLine: '데이터 무제한 최대 5Mbps 속도',
     link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000415',
+    isActive: true,
   },
-  //중용량데이터
   {
+    _id: '6858ee7ffc03f10c8671010a',
     id: 'data-medium',
     name: '5G 데이터 플러스',
     description:
@@ -126,6 +149,7 @@ export const planResults: PlanResult[] = [
     price: 66000,
     tagLine: '데이터 무제한 최대 1Mbps 속도',
     link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000782',
+    isActive: true,
   },
 ];
 

--- a/client/src/pages/TestPage.tsx
+++ b/client/src/pages/TestPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { rules } from '@/utils/rules';
-import { planResults } from '@/data/TestResult';
+// import { planResults } from '@/data/TestResult';
+import { getAllPlans } from '@/api/testPlan';
 import { questions } from '@/data/Questions';
 import Modal from '@/components/common/Modal';
 import Button from '@/components/common/Button';
@@ -16,6 +17,160 @@ import next from '../assets/icon/next_icon.svg';
 import back from '../assets/icon/back_icon.svg';
 import { useRef } from 'react';
 import type { PlanResult } from '@/components/types/TestResult';
+
+// 컴포넌트 외부로 이동하여 재생성 방지
+const localFallbackPlans: PlanResult[] = [
+  {
+    _id: '6858ee7ffc03f10c86710103',
+    id: 'ott-plus',
+    name: '5G 프리미어 플러스',
+    description:
+      'U⁺5G 서비스는 물론, 스마트 기기 2개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제\n프리미엄 서비스 기본 제공(택1)\n음악 구독 서비스 지니, 벅스, FLO 중 선택 가능',
+    priority: 2,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 105000,
+    tagLine: '넷플릭스 / 왓챠 제휴 결합',
+    link: 'https://www.lguplus.com/plan/limit-plans/Z202205254',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710105',
+    id: 'youth1-special',
+    name: '5G 라이트 청소년',
+    description:
+      '저렴한 요금으로 실속있게 U⁺5G 서비스를 이용할 수 있는 청소년 전용 5G 요금제\n최대 1Mbps 속도로 데이터 무제한 이용 가능\n만 18세 이하만 가입가능',
+    priority: 1,
+    dataUsage: 15,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 45000,
+    tagLine: '데이터 무제한 최대 1Mbps 속도',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-youth/LPZ0000417',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710106',
+    id: 'youth2-special',
+    name: '유스 5G 스탠다드',
+    description:
+      '일반 5G요금제보다 더 넉넉한 데이터를 이용할 수 있는 청년 전용 5G요금제\n만 19세 이상 만 34세 이하 청년만 가입가능',
+    priority: 1,
+    dataUsage: 90,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 75000,
+    tagLine: '데이터 무제한 최대 5Mbps 속도',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-young/LPZ1000232',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710107',
+    id: 'youth3-special',
+    name: 'LTE 데이터 시니어 33',
+    description:
+      '음성통화와 문자메시지는 기본으로 사용하고 저렴한 요금으로 데이터를 이용할 수 있는 실속형 시니어 전용 LTE 요금제\n1시간~3시간마다 문자메시지로 내 위치를 보호자에게 알려주는 실버지킴이 서비스',
+    priority: 1,
+    dataUsage: 5,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 33000,
+    tagLine: '실버지킴이 서비스',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/lte-all/lte-senior/LPZ0000296',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710103',
+    id: 'ott-plus',
+    name: '5G 프리미어 플러스',
+    description:
+      'U⁺5G 서비스는 물론, 스마트 기기 2개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제\n프리미엄 서비스 기본 제공(택1)\n음악 구독 서비스 지니, 벅스, FLO 중 선택 가능',
+    priority: 2,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 105000,
+    tagLine: '넷플릭스 / 왓챠 제휴 결합',
+    link: 'https://www.lguplus.com/plan/limit-plans/Z202205254',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710102',
+    id: 'music-plus',
+    name: '5G 프리미어 레귤러',
+    description:
+      'U⁺5G 서비스는 물론, 스마트기기 1개와 다양한 콘텐츠까지 마음껏 이용할 수 있는 5G 요금제\n미디어 서비스 기본 제공(택1)\n지니, 벅스, FLO 중 선택 가능',
+    priority: 3,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 95000,
+    tagLine: '지니뮤직 제휴 결합',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000433',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710104',
+    id: 'family',
+    name: '5G 프리미어 에센셜',
+    description:
+      'U⁺5G 서비스를 마음껏 즐길 수 있는 5G 요금제\n친구, 가족과 결합하면 데이터 무제한 요금제를 최대 20,000원 할인',
+    priority: 4,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 85000,
+    tagLine: 'U+ 투게더 결합',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000409',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710108',
+    id: 'max-data',
+    name: '5G 프리미어 에센셜',
+    description:
+      'U⁺5G 서비스를 마음껏 즐길 수 있는 5G 요금제\nU+ 투게더 결합\n프리미어 요금제 약정할인\n로밍 혜택 프로모션',
+    priority: 5,
+    dataUsage: 100,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 85000,
+    tagLine: '데이터 무제한',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000409',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c86710109',
+    id: 'data-high',
+    name: '5G 스탠다드',
+    description:
+      '넉넉한 데이터로 U⁺5G 서비스를 이용할 수 있는 5G 표준 요금제\n최대 5Mbps 속도로 데이터 무제한 이용 가능',
+    priority: 5,
+    dataUsage: 80,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 75000,
+    tagLine: '데이터 무제한 최대 5Mbps 속도',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000415',
+    isActive: true,
+  },
+  {
+    _id: '6858ee7ffc03f10c8671010a',
+    id: 'data-medium',
+    name: '5G 데이터 플러스',
+    description:
+      '필요한 만큼만 데이터를 선택할 수 있고, 다 쓰고 난 후에도 추가 요금 없이 데이터를 사용할 수 있는 요금제\n최대 1Mbps 속도로 데이터 무제한 이용 가능',
+    priority: 5,
+    dataUsage: 60,
+    callUsage: 100,
+    messageUsage: 100,
+    price: 66000,
+    tagLine: '데이터 무제한 최대 1Mbps 속도',
+    link: 'https://www.lguplus.com/mobile/plan/mplan/5g-all/5g-unlimited/LPZ0000782',
+    isActive: true,
+  },
+];
 
 const TestPage = () => {
   const navigate = useNavigate();
@@ -32,6 +187,23 @@ const TestPage = () => {
   const selected = selectedOptions[currentQuestion.id];
   const isAnswered = selected !== undefined;
   const moonerSrc = isAnswered ? moonerAhaImage : moonerImage;
+  const [fetchedPlans, setFetchedPlans] = useState<PlanResult[]>([]);
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      // setIsLoading(true);
+      try {
+        const res = await getAllPlans();
+        setFetchedPlans(res.planResults); // or res if 직접 리턴 시
+      } catch (error) {
+        console.error('요금제 가져오기 실패:', error);
+        setFetchedPlans(localFallbackPlans);
+      }
+      // setIsLoading(false);
+    };
+
+    fetchPlans();
+  }, []);
 
   // const handleGoHome = () => {
   //   navigate('/'); // 메인페이지로 이동
@@ -71,11 +243,7 @@ const TestPage = () => {
   const allAnswered = questions.every(
     (q) => selectedOptions[q.id] !== undefined,
   );
-
-  // const getRecommendedPlan = (answers: { [key: number]: string }) => {
-  //   return TestResult.find((plan) => plan.condition(answers))!;
-  // };
-
+  
   return (
     <div className="h-screen flex flex-col">
       <Header
@@ -168,10 +336,11 @@ const TestPage = () => {
                     );
 
                     const matchedPlans = matchedRules
-                      .map((rule) =>
-                        planResults.find((p) => p.id === rule.resultId),
-                      )
-                      .filter((p): p is PlanResult => !!p);
+                      .map((rule) => {
+                        if (!rule?.resultId) return undefined;
+                        return fetchedPlans.find((p) => p.id === rule.resultId);
+                      })
+                      .filter((p): p is PlanResult => !!p); // null/undefined 제거
 
                     const sortedPlans = matchedPlans.sort(
                       (a, b) => a.priority - b.priority,

--- a/client/src/pages/TestResultPage.tsx
+++ b/client/src/pages/TestResultPage.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import type { PlanResult } from '@/components/types/TestResult';
-import { planResults } from '@/data/TestResult';
-
+// import { planResults } from '@/data/TestResult';
+import { getAllPlans } from '@/api/testPlan';
 import UsageBar from '@/components/testPage/UsageBar';
 import moonerFunImage from '../assets/image/mooner_fun.png';
 import Header from '@/components/common/Header';
@@ -49,12 +49,20 @@ const TestResultPage = () => {
   const [plan, setPlan] = useState<PlanResult | null>(null);
 
   useEffect(() => {
-    if (planId) {
-      const matched = planResults.find((p) => p.id === planId);
-      if (matched) {
-        setPlan(matched);
+    const fetchPlan = async () => {
+      if (!planId || typeof planId !== 'string') return;
+
+      try {
+        const res = await getAllPlans();
+        const matched = res.planResults.find((p) => p.id === planId);
+        if (matched) setPlan(matched);
+        else console.warn('해당 ID에 맞는 요금제가 없습니다.');
+      } catch (err) {
+        console.error('요금제 조회 실패:', err);
       }
-    }
+    };
+
+    fetchPlan();
   }, [planId]);
 
   if (!planId) {


### PR DESCRIPTION
## 📝 변경 사항
요금제 추천 페이지 API 연동 및 불필요한 코드 정리

## 🔍 변경 사항 세부 설명

- TestPage.tsx에서 더미 데이터 제거 및 getAllPlans API 연동 완료
- API 실패 시 fallback 요금제(localFallbackPlans) 사용하도록 처리
- 기존 planResults import 제거

## 🕵️‍♀️ 요청사항
X

## 📷 스크린샷 (선택)
X

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
